### PR TITLE
Change partition table to get more space for the application

### DIFF
--- a/Platformio/platformio.ini
+++ b/Platformio/platformio.ini
@@ -15,6 +15,7 @@ framework = arduino
 monitor_speed = 115200
 board_build.f_flash = 80000000L
 board_build.f_cpu = 240000000L
+board_build.partitions = huge_app.csv
 upload_speed = 1000000
 lib_deps = 
 	sparkfun/SparkFun LIS3DH Arduino Library@^1.0.3


### PR DESCRIPTION
The used CPU has 4MB of flash memory. With the default settings only 1310720 bytes are used for the program Current omote with default settings: Flash: [========= ]  85.1% (used 1115225 bytes from 1310720 bytes)

Using a different partition table will solve this problem. 

As the OTA feature is not needed this partition can be used for the application. With this partition table 3145728 bytes are available for the application

Flash: [====      ]  35.5% (used 1115225 bytes from 3145728 bytes)