### PR TITLE
Fixes a wifi stability issue.

### DIFF
--- a/Platformio/src/hardware/mqtt.cpp
+++ b/Platformio/src/hardware/mqtt.cpp
@@ -27,6 +27,7 @@ void WiFiEvent(WiFiEvent_t event){
     if (WifiLabel != NULL) {lv_label_set_text(WifiLabel, "");}
     // automatically try to reconnect
     Serial.printf("WiFi got disconnected. Will try to reconnect.\r\n");
+    WiFi.disconnect();
     WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
 
   } else {


### PR DESCRIPTION
WiFi library attempts to connect to a broken connection and fails until a sleep cycle is performed. This is solved by ending the current broken connection using WiFi.disconnect() before we attempt to start a new connection.