### PR TITLE
Assist function for MQTT messages

### DIFF
--- a/Platformio/src/applicationInternal/gui/guiBase.cpp
+++ b/Platformio/src/applicationInternal/gui/guiBase.cpp
@@ -115,6 +115,27 @@ void tabview_tab_changed_event_cb(lv_event_t* e) {
   }
 }
 
+void tabview_tab_changed_manually(uint32_t current_tabID) {
+  oldTabID = currentTabID;
+  currentTabID = current_tabID;
+
+  // Wait until the animation ended, then call "guis_doAfterSliding(oldTabID, currentTabID, false);"
+  // https://forum.lvgl.io/t/delete-a-tab-after-the-tabview-scroll-animation-is-complete/3155/4
+  lv_obj_t* tabContainer = lv_tabview_get_content(tabview);
+  // https://docs.lvgl.io/8.3/overview/animation.html?highlight=lv_anim_get#_CPPv411lv_anim_getPv18lv_anim_exec_xcb_t
+  // (lv_anim_exec_xcb_t) lv_obj_set_x does not find an animation. NULL is good as well.
+  lv_anim_t* anim = lv_anim_get(tabContainer, NULL); // (lv_anim_exec_xcb_t) lv_obj_set_x);
+  if(anim) {
+    // Swipe is not yet complete. User released the touch screen, an animation will bring it to the end.
+    // That's the normal (and only?) case for the tft touchscreen
+    lv_anim_set_ready_cb(anim, tabview_animation_ready_cb);
+  } else {
+    // Swipe is complete, no additional animation is needed. Most likely only possible in simulator
+    Serial.println("Change of tab detected, without animation at the end. Will directly do my job after sliding.");
+    guis_doAfterSliding(oldTabID, currentTabID, false);
+  }
+}
+
 void setMainWidgetsHeightAndPosition();
 void init_gui_status_bar();
 void init_gui_memoryUsage_bar();

--- a/Platformio/src/applicationInternal/gui/guiBase.h
+++ b/Platformio/src/applicationInternal/gui/guiBase.h
@@ -30,6 +30,7 @@ void gui_loop(void);
 // used by guiMemoryOptimizer.cpp
 void tabview_content_is_scrolling_event_cb(lv_event_t* e);
 void tabview_tab_changed_event_cb(lv_event_t* e);
+void tabview_tab_changed_manually(uint32_t current_tabID);
 void sceneLabel_or_pageIndicator_event_cb(lv_event_t* e);
 void setActiveTab(uint32_t index, lv_anim_enable_t anim_en);
 // used by memoryUsage.cpp

--- a/Platformio/src/applicationInternal/gui/guiMemoryOptimizer.cpp
+++ b/Platformio/src/applicationInternal/gui/guiMemoryOptimizer.cpp
@@ -249,6 +249,17 @@ void getBreadcrumpPosition(uint8_t* breadcrumpPosition, std::string nameOfTab) {
   }
 }
 
+void sidepanel_click_event_cb(lv_event_t *e) {
+  lv_obj_t *target = lv_event_get_target(e);
+  int user_data = (intptr_t)(target->user_data);
+  if (tabs_in_memory[2].listIndex == -1) {
+    if (user_data == 2) user_data = 1;
+  }
+  Serial.printf("  Sides of bottom bar clicked, swiping left(0) or right(1|2): %d\r\n", user_data);
+  setActiveTab(user_data, LV_ANIM_ON);
+  tabview_tab_changed_manually((uint32_t) user_data);
+}
+
 void fillPanelWithPageIndicator_strategyMax3(lv_obj_t* panel, lv_obj_t* img1, lv_obj_t* img2) {
   Serial.printf("  Will fill panel with page indicators\r\n");
 
@@ -309,6 +320,14 @@ void fillPanelWithPageIndicator_strategyMax3(lv_obj_t* panel, lv_obj_t* img1, lv
       if (nameOfTab == get_currentGUIname()) {
         lv_obj_add_flag(btn, LV_OBJ_FLAG_CLICKABLE);
         lv_obj_add_event_cb(btn, sceneLabel_or_pageIndicator_event_cb, LV_EVENT_CLICKED, NULL);
+      } else {
+        lv_obj_add_flag(btn, LV_OBJ_FLAG_CLICKABLE);
+        if (tabs_in_memory[0].listIndex == -1) {
+          lv_obj_set_user_data(btn,(void *)(intptr_t)2);
+        } else {
+          lv_obj_set_user_data(btn,(void *)(intptr_t)i); 
+        }
+        lv_obj_add_event_cb(btn, sidepanel_click_event_cb, LV_EVENT_CLICKED, NULL);
       }
       lv_obj_set_size(btn, 150, lv_pct(100));
       lv_obj_remove_style(btn, NULL, LV_STATE_PRESSED);

--- a/Platformio/src/applicationInternal/gui/guiMemoryOptimizer.cpp
+++ b/Platformio/src/applicationInternal/gui/guiMemoryOptimizer.cpp
@@ -491,3 +491,18 @@ void gui_memoryOptimizer_doAfterSliding_deletionAndCreation(lv_obj_t** tabview, 
   Serial.printf("------------ End of tab deletion and creation\r\n");
 
 }
+
+bool checkTabActive(std::string tabName) {
+  bool tabnameIsActive = false;
+  if ((tabs_in_memory[1].guiName == tabName) && (tabs_in_memory[2].listIndex > 0)) tabnameIsActive = true;
+  if ((tabs_in_memory[0].guiName == tabName) && (tabs_in_memory[2].listIndex < 0)) tabnameIsActive = true;
+  return tabnameIsActive;
+}
+
+bool checkTabinMemory(std::string tabName) {
+  bool tabnameIsActive = false;
+  for (uint8_t i = 0; i < 3; i++) {
+    if (tabs_in_memory[i].guiName == tabName) tabnameIsActive = true;
+  }
+  return tabnameIsActive;
+}

--- a/Platformio/src/applicationInternal/gui/guiMemoryOptimizer.h
+++ b/Platformio/src/applicationInternal/gui/guiMemoryOptimizer.h
@@ -2,3 +2,5 @@
 
 void gui_memoryOptimizer_prepare_startup();
 void gui_memoryOptimizer_doAfterSliding_deletionAndCreation(lv_obj_t** tabview, int oldTabID, int newTabID, bool newGuiList, lv_obj_t** panel, lv_obj_t** img1, lv_obj_t** img2);
+bool checkTabActive(std::string tabName);
+bool checkTabinMemory(std::string tabName);


### PR DESCRIPTION
The two functions at the end of guiMemoryOptimizer can be used to determine if the widgets on the tab you want to update are currently loaded into memory or visible on screen.

When a MQTT message arrives and you will want to update the gui accordingly, you need to know if the gui is loaded into memory and/or visible at this moment. These functions can then be called from the gui itself to check if an immediate update is needed/possible.

The other updates in guiMemoryOptimizer and guiBase change the behaviour of the panelindicators: when you click the middle panelindicator everything is the same as it was, you open the scene selector. But if you click on the partially visible indicators next to the current active panel this creates a opposite swipe gesture effect. So if you click on the right indicator, the next screen to the right swipes in view (if available) and vice versa for the left.

This is an addition to the swiping gestures so you can swipe and click.