### PR TITLE
Added slider to settings gui for adjusting wake up sensitivity

### DIFF
--- a/Platformio/hardware/ESP32/preferencesStorage_hal_esp32.cpp
+++ b/Platformio/hardware/ESP32/preferencesStorage_hal_esp32.cpp
@@ -19,7 +19,7 @@ void init_preferences_HAL(void) {
     // from here
     currentScene = std::string(preferences.getString("currentScene").c_str());
     currentGUIname = std::string(preferences.getString("currentGUIname").c_str());
-    set_wakeupByIMUthreshold_HAL(preferences.getUChar("threshold"));
+    set_wakeupByIMUthreshold_HAL(preferences.getUChar("threshold", 0x45));
     
     // Serial.printf("Preferences restored: brightness %d, GUI %s, scene %s\r\n", get_backlightBrightness_HAL(), get_currentGUIname().c_str(), get_currentScene().c_str());
   } else {

--- a/Platformio/hardware/ESP32/preferencesStorage_hal_esp32.cpp
+++ b/Platformio/hardware/ESP32/preferencesStorage_hal_esp32.cpp
@@ -19,7 +19,8 @@ void init_preferences_HAL(void) {
     // from here
     currentScene = std::string(preferences.getString("currentScene").c_str());
     currentGUIname = std::string(preferences.getString("currentGUIname").c_str());
-
+    set_wakeupByIMUthreshold_HAL(preferences.getUChar("threshold"));
+    
     // Serial.printf("Preferences restored: brightness %d, GUI %s, scene %s\r\n", get_backlightBrightness_HAL(), get_currentGUIname().c_str(), get_currentScene().c_str());
   } else {
     // Serial.printf("No preferences to restore\r\n");
@@ -37,6 +38,8 @@ void save_preferences_HAL(void) {
   // from here
   preferences.putString("currentScene", currentScene.c_str());
   preferences.putString("currentGUIname", currentGUIname.c_str());
+  preferences.putUChar("threshold", get_wakeupByIMUthreshold_HAL());
+
   if (!preferences.getBool("alreadySetUp")) {
     preferences.putBool("alreadySetUp", true);
   }

--- a/Platformio/hardware/ESP32/preferencesStorage_hal_esp32.cpp
+++ b/Platformio/hardware/ESP32/preferencesStorage_hal_esp32.cpp
@@ -19,7 +19,7 @@ void init_preferences_HAL(void) {
     // from here
     currentScene = std::string(preferences.getString("currentScene").c_str());
     currentGUIname = std::string(preferences.getString("currentGUIname").c_str());
-    set_wakeupByIMUthreshold_HAL(preferences.getUChar("threshold", 0x45));
+    set_wakeupByIMUthreshold_HAL(preferences.getUChar("threshold", 0x3A));
     
     // Serial.printf("Preferences restored: brightness %d, GUI %s, scene %s\r\n", get_backlightBrightness_HAL(), get_currentGUIname().c_str(), get_currentScene().c_str());
   } else {

--- a/Platformio/hardware/ESP32/sleep_hal_esp32.cpp
+++ b/Platformio/hardware/ESP32/sleep_hal_esp32.cpp
@@ -26,9 +26,18 @@ bool wakeupByIMUEnabled = true;
 uint32_t sleepTimeout;
 // Timestamp of the last activity. Go to sleep if (millis() - lastActivityTimestamp > sleepTimeout)
 uint32_t lastActivityTimestamp;
+char wakeupByIMUthreshold;
 
 LIS3DH IMU(I2C_MODE, 0x19);
 Wakeup_reasons wakeup_reason;
+
+char get_wakeupByIMUthreshold_HAL() {
+  return wakeupByIMUthreshold;
+}
+void set_wakeupByIMUthreshold_HAL(char awakeupByIMUthreshold) {
+  if (awakeupByIMUthreshold > 0x7F) awakeupByIMUthreshold = 0x7F;
+  wakeupByIMUthreshold = awakeupByIMUthreshold;
+}
 
 void setLastActivityTimestamp_HAL() {
   // There was motion, touchpad or key hit.
@@ -85,9 +94,9 @@ void configIMUInterruptsBeforeGoingToSleep()
   //LIS3DH_INT1_THS   
   dataToWrite = 0;
   //Provide 7 bit value, 0x7F always equals max range by accelRange setting
-  dataToWrite |= 0x45;
+  dataToWrite |= (0x7F - get_wakeupByIMUthreshold_HAL());
   IMU.writeRegister(LIS3DH_INT1_THS, dataToWrite);
-  
+
   //LIS3DH_INT1_DURATION  
   dataToWrite = 0;
   //minimum duration of the interrupt

--- a/Platformio/hardware/ESP32/sleep_hal_esp32.cpp
+++ b/Platformio/hardware/ESP32/sleep_hal_esp32.cpp
@@ -35,8 +35,7 @@ char get_wakeupByIMUthreshold_HAL() {
   return wakeupByIMUthreshold;
 }
 void set_wakeupByIMUthreshold_HAL(char awakeupByIMUthreshold) {
-  if (awakeupByIMUthreshold > 0x7F) awakeupByIMUthreshold = 0x7F;
-  if (awakeupByIMUthreshold < 0x40) awakeupByIMUthreshold = 0x40;
+  if (awakeupByIMUthreshold > 0x3F) awakeupByIMUthreshold = 0x3F;
   wakeupByIMUthreshold = awakeupByIMUthreshold;
 }
 

--- a/Platformio/hardware/ESP32/sleep_hal_esp32.cpp
+++ b/Platformio/hardware/ESP32/sleep_hal_esp32.cpp
@@ -36,6 +36,7 @@ char get_wakeupByIMUthreshold_HAL() {
 }
 void set_wakeupByIMUthreshold_HAL(char awakeupByIMUthreshold) {
   if (awakeupByIMUthreshold > 0x7F) awakeupByIMUthreshold = 0x7F;
+  if (awakeupByIMUthreshold < 0x40) awakeupByIMUthreshold = 0x40;
   wakeupByIMUthreshold = awakeupByIMUthreshold;
 }
 

--- a/Platformio/hardware/ESP32/sleep_hal_esp32.h
+++ b/Platformio/hardware/ESP32/sleep_hal_esp32.h
@@ -19,3 +19,5 @@ uint32_t get_sleepTimeout_HAL();
 void set_sleepTimeout_HAL(uint32_t aSleepTimeout);
 bool get_wakeupByIMUEnabled_HAL();
 void set_wakeupByIMUEnabled_HAL(bool aWakeupByIMUEnabled);
+char get_wakeupByIMUthreshold_HAL();
+void set_wakeupByIMUthreshold_HAL(char awakeupByIMUthreshold);

--- a/Platformio/hardware/windows_linux/sleep_hal_windows_linux.cpp
+++ b/Platformio/hardware/windows_linux/sleep_hal_windows_linux.cpp
@@ -5,6 +5,7 @@
 bool wakeupByIMUEnabled = true;
 // timeout before going to sleep
 uint32_t sleepTimeout;
+char wakeupByIMUthreshold;
 
 void init_sleep_HAL() {}
 void init_IMU_HAL(void) {}
@@ -24,4 +25,11 @@ bool get_wakeupByIMUEnabled_HAL() {
 void set_wakeupByIMUEnabled_HAL(bool aWakeupByIMUEnabled) {
   wakeupByIMUEnabled = aWakeupByIMUEnabled;
   printf("lift to wake set to %d\r\n", aWakeupByIMUEnabled);
+}
+char get_wakeupByIMUthreshold_HAL() {
+  return wakeupByIMUthreshold;
+}
+void set_wakeupByIMUthreshold_HAL(char awakeupByIMUthreshold) {
+  if (awakeupByIMUthreshold > 0x7F) awakeupByIMUthreshold = 0x7F;
+  wakeupByIMUthreshold = awakeupByIMUthreshold;
 }

--- a/Platformio/hardware/windows_linux/sleep_hal_windows_linux.h
+++ b/Platformio/hardware/windows_linux/sleep_hal_windows_linux.h
@@ -9,3 +9,5 @@ uint32_t get_sleepTimeout_HAL();
 void set_sleepTimeout_HAL(uint32_t aSleepTimeout);
 bool get_wakeupByIMUEnabled_HAL();
 void set_wakeupByIMUEnabled_HAL(bool aWakeupByIMUEnabled);
+char get_wakeupByIMUthreshold_HAL();
+void set_wakeupByIMUthreshold_HAL(char awakeupByIMUthreshold);

--- a/Platformio/src/applicationInternal/hardware/hardwarePresenter.cpp
+++ b/Platformio/src/applicationInternal/hardware/hardwarePresenter.cpp
@@ -80,6 +80,12 @@ bool get_wakeupByIMUEnabled() {
 void set_wakeupByIMUEnabled(bool aWakeupByIMUEnabled) {
   set_wakeupByIMUEnabled_HAL(aWakeupByIMUEnabled);
 }
+char get_wakeupByIMUthreshold() {
+  return get_wakeupByIMUthreshold_HAL();
+}
+void set_wakeupByIMUthreshold(char awakeupByIMUthreshold) {
+  set_wakeupByIMUthreshold_HAL(awakeupByIMUthreshold);
+}
 
 // --- keypad -----------------------------------------------------------------
 void init_keys(void) {

--- a/Platformio/src/applicationInternal/hardware/hardwarePresenter.h
+++ b/Platformio/src/applicationInternal/hardware/hardwarePresenter.h
@@ -32,6 +32,8 @@ uint32_t get_sleepTimeout();
 void set_sleepTimeout(uint32_t aSleepTimeout);
 bool get_wakeupByIMUEnabled();
 void set_wakeupByIMUEnabled(bool aWakeupByIMUEnabled);
+char get_wakeupByIMUthreshold();
+void set_wakeupByIMUthreshold(char awakeupByIMUthreshold);
 
 // --- keypad -----------------------------------------------------------------
 void init_keys(void);

--- a/Platformio/src/guis/gui_settings.cpp
+++ b/Platformio/src/guis/gui_settings.cpp
@@ -148,7 +148,7 @@ void create_tab_content_settings(lv_obj_t* tab) {
   lv_label_set_text(menuLabel, "Wake up sensitivity");
   lv_obj_align(menuLabel, LV_ALIGN_TOP_LEFT, 0, 94);
   lv_obj_t *thslider = lv_slider_create(menuBox);
-  lv_slider_set_range(thslider, 0x40, 0x7F);
+  lv_slider_set_range(thslider, 0, 0x3F);
   lv_obj_set_style_bg_color(thslider, lv_color_white(), LV_PART_KNOB);
   lv_obj_set_style_bg_opa(thslider, LV_OPA_COVER, LV_PART_MAIN);
   lv_obj_set_style_bg_color(thslider, lv_color_lighten(color_primary, 50), LV_PART_MAIN);

--- a/Platformio/src/guis/gui_settings.cpp
+++ b/Platformio/src/guis/gui_settings.cpp
@@ -25,8 +25,8 @@ static void bl_slider_event_cb(lv_event_t* e){
 static void th_slider_event_cb(lv_event_t* e){
   lv_obj_t* slider = lv_event_get_target(e);
   int32_t slider_value = lv_slider_get_value(slider);
-  if (slider_value < 0)  {slider_value = 0;}
-  if (slider_value > 127) {slider_value = 127;}
+  if (slider_value < 0x40)  {slider_value = 0x40;}
+  if (slider_value > 0x7F) {slider_value = 0x7F;}
   set_wakeupByIMUthreshold((char) slider_value);
 }
 
@@ -148,7 +148,7 @@ void create_tab_content_settings(lv_obj_t* tab) {
   lv_label_set_text(menuLabel, "Wake up sensitivity");
   lv_obj_align(menuLabel, LV_ALIGN_TOP_LEFT, 0, 94);
   lv_obj_t *thslider = lv_slider_create(menuBox);
-  lv_slider_set_range(thslider, 0, 127);
+  lv_slider_set_range(thslider, 0x40, 0x7F);
   lv_obj_set_style_bg_color(thslider, lv_color_white(), LV_PART_KNOB);
   lv_obj_set_style_bg_opa(thslider, LV_OPA_COVER, LV_PART_MAIN);
   lv_obj_set_style_bg_color(thslider, lv_color_lighten(color_primary, 50), LV_PART_MAIN);

--- a/Platformio/src/guis/gui_settings.cpp
+++ b/Platformio/src/guis/gui_settings.cpp
@@ -22,6 +22,14 @@ static void bl_slider_event_cb(lv_event_t* e){
   set_backlightBrightness(slider_value);
 }
 
+static void th_slider_event_cb(lv_event_t* e){
+  lv_obj_t* slider = lv_event_get_target(e);
+  int32_t slider_value = lv_slider_get_value(slider);
+  if (slider_value < 0)  {slider_value = 0;}
+  if (slider_value > 127) {slider_value = 127;}
+  set_wakeupByIMUthreshold((char) slider_value);
+}
+
 // Wakeup by IMU Switch Event handler
 static void WakeEnableSetting_event_cb(lv_event_t* e){
   set_wakeupByIMUEnabled(lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED));
@@ -64,7 +72,7 @@ void create_tab_content_settings(lv_obj_t* tab) {
   lv_label_set_text(menuLabel, "Display");
 
   lv_obj_t* menuBox = lv_obj_create(tab);
-  lv_obj_set_size(menuBox, lv_pct(100), 109);
+  lv_obj_set_size(menuBox, lv_pct(100), 160);
   lv_obj_set_style_bg_color(menuBox, color_primary, LV_PART_MAIN);
   lv_obj_set_style_border_width(menuBox, 0, LV_PART_MAIN);
 
@@ -134,6 +142,20 @@ void create_tab_content_settings(lv_obj_t* tab) {
   lv_obj_set_style_border_width(lv_dropdown_get_list(drop), 1, LV_PART_MAIN);
   lv_obj_set_style_border_color(lv_dropdown_get_list(drop), lv_color_hex(0x505050), LV_PART_MAIN);
   lv_obj_add_event_cb(drop, timout_event_cb, LV_EVENT_VALUE_CHANGED, NULL);
+
+  // Add text & slider for sensitivity setting
+  menuLabel = lv_label_create(menuBox);
+  lv_label_set_text(menuLabel, "Wake up sensitivity");
+  lv_obj_align(menuLabel, LV_ALIGN_TOP_LEFT, 0, 94);
+  lv_obj_t *thslider = lv_slider_create(menuBox);
+  lv_slider_set_range(thslider, 0, 127);
+  lv_obj_set_style_bg_color(thslider, lv_color_white(), LV_PART_KNOB);
+  lv_obj_set_style_bg_opa(thslider, LV_OPA_COVER, LV_PART_MAIN);
+  lv_obj_set_style_bg_color(thslider, lv_color_lighten(color_primary, 50), LV_PART_MAIN);
+  lv_slider_set_value(thslider, get_wakeupByIMUthreshold(), LV_ANIM_OFF);
+  lv_obj_set_size(thslider, lv_pct(90), 10);
+  lv_obj_align(thslider, LV_ALIGN_TOP_LEFT, 10, 124);
+  lv_obj_add_event_cb(thslider, th_slider_event_cb, LV_EVENT_VALUE_CHANGED, NULL);
 
   // // Add another label, then a settings box for WiFi
   // menuLabel = lv_label_create(tab);


### PR DESCRIPTION
The settings page now has an added slider with which you can adjust the sensitivity of movement detection for waking up Omote. After adjusting the slider the changes take effect when Omote falls to sleep again.

The greater the value of the slider (the more you slide it to the right), the more sensitive Omote is for movement to wake it up again.
