### PR TITLE
Run github actions on pull requests

### DIFF
--- a/.github/workflows/build-platformio-macos.yml
+++ b/.github/workflows/build-platformio-macos.yml
@@ -1,17 +1,10 @@
 name: macOS build
 
-on: [push,workflow_dispatch]
+on: [push,workflow_dispatch, pull_request]
 
 jobs:
   build:
     runs-on: macos-latest
-
-
-
-
-
-
-
 
     steps:
       - uses: actions/checkout@v4
@@ -28,23 +21,6 @@ jobs:
       - name: Install SDL2
         run: |
           brew install sdl2 sdl2_image
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio

--- a/.github/workflows/build-platformio-ubuntu.yml
+++ b/.github/workflows/build-platformio-ubuntu.yml
@@ -1,17 +1,10 @@
 name: Ubuntu build
 
-on: [push,workflow_dispatch]
+on: [push,workflow_dispatch,pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
-
-
-
-
-
-
 
     steps:
       - uses: actions/checkout@v4
@@ -30,21 +23,6 @@ jobs:
           sudo apt update
           sudo apt upgrade -y
           sudo apt install -y libsdl2-dev libsdl2-image-dev
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio

--- a/.github/workflows/build-platformio-windows.yml
+++ b/.github/workflows/build-platformio-windows.yml
@@ -1,6 +1,6 @@
 name: Windows build
 
-on: [push,workflow_dispatch]
+on: [push,workflow_dispatch,pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This makes it easier to see build failures and talk about issues with more context instead of tracking down a specific build on a fork