### PR TITLE
Consistent naming of sleep functions for ble and mqtt

### DIFF
--- a/Platformio/hardware/ESP32/keyboard_ble_hal_esp32.cpp
+++ b/Platformio/hardware/ESP32/keyboard_ble_hal_esp32.cpp
@@ -173,7 +173,7 @@ bool keyboardBLE_isConnected_HAL() {
   return bleKeyboard.isConnected();
 }
 
-void keyboardBLE_end_HAL() {
+void keyboard_ble_shutdown_HAL() {
   bleKeyboard.end();
 }
     

--- a/Platformio/hardware/ESP32/keyboard_ble_hal_esp32.h
+++ b/Platformio/hardware/ESP32/keyboard_ble_hal_esp32.h
@@ -21,7 +21,7 @@ void set_announceBLEmessage_cb_HAL(tAnnounceBLEmessage_cb pAnnounceBLEmessage_cb
 void init_keyboardBLE_HAL();
 bool keyboardBLE_isAdvertising_HAL();
 bool keyboardBLE_isConnected_HAL();
-void keyboardBLE_end_HAL();
+void keyboard_ble_shutdown_HAL();
 void keyboardBLE_write_HAL(uint8_t c);
 void keyboardBLE_longpress_HAL(uint8_t c);
 void keyboardBLE_home_HAL();

--- a/Platformio/hardware/ESP32/mqtt_hal_esp32.cpp
+++ b/Platformio/hardware/ESP32/mqtt_hal_esp32.cpp
@@ -213,7 +213,7 @@ bool publishMQTTMessage_HAL(const char *topic, const char *payload){
   return false;
 }
 
-void wifiStop_HAL() {
+void wifi_shutdown_HAL() {
   WiFi.disconnect();
   WiFi.mode(WIFI_OFF);
 }

--- a/Platformio/hardware/ESP32/mqtt_hal_esp32.h
+++ b/Platformio/hardware/ESP32/mqtt_hal_esp32.h
@@ -6,7 +6,7 @@ void init_mqtt_HAL(void);
 bool getIsWifiConnected_HAL();
 void mqtt_loop_HAL();
 bool publishMQTTMessage_HAL(const char *topic, const char *payload);
-void wifiStop_HAL();
+void wifi_shutdown_HAL();
 
 typedef void (*tAnnounceWiFiconnected_cb)(bool connected);
 void set_announceWiFiconnected_cb_HAL(tAnnounceWiFiconnected_cb pAnnounceWiFiconnected_cb);

--- a/Platformio/hardware/ESP32/sleep_hal_esp32.cpp
+++ b/Platformio/hardware/ESP32/sleep_hal_esp32.cpp
@@ -146,11 +146,11 @@ void enterSleep(){
 
   #if (ENABLE_WIFI_AND_MQTT == 1)
   // Power down modem
-  wifiStop_HAL();
+  wifi_shutdown_HAL();
   #endif
 
   #if (ENABLE_KEYBOARD_BLE == 1)
-  keyboardBLE_end_HAL();
+  keyboard_ble_shutdown_HAL();
   #endif
 
   // Prepare IO states

--- a/Platformio/hardware/windows_linux/keyboard_ble_hal_windows_linux.cpp
+++ b/Platformio/hardware/windows_linux/keyboard_ble_hal_windows_linux.cpp
@@ -29,7 +29,7 @@ void set_announceBLEmessage_cb_HAL(tAnnounceBLEmessage_cb pAnnounceBLEmessage_cb
 void init_keyboardBLE_HAL() {};
 bool keyboardBLE_isAdvertising_HAL() {return false;};
 bool keyboardBLE_isConnected_HAL() {return false;};
-void keyboardBLE_end_HAL() {};
+void keyboard_ble_shutdown_HAL() {};
 void keyboardBLE_write_HAL(uint8_t c) {};
 void keyboardBLE_longpress_HAL(uint8_t c) {};
 void keyboardBLE_home_HAL() {};

--- a/Platformio/hardware/windows_linux/keyboard_ble_hal_windows_linux.h
+++ b/Platformio/hardware/windows_linux/keyboard_ble_hal_windows_linux.h
@@ -39,7 +39,7 @@ void set_announceBLEmessage_cb_HAL(tAnnounceBLEmessage_cb pAnnounceBLEmessage_cb
 void init_keyboardBLE_HAL();
 bool keyboardBLE_isAdvertising_HAL();
 bool keyboardBLE_isConnected_HAL();
-void keyboardBLE_end_HAL();
+void keyboard_ble_shutdown_HAL();
 void keyboardBLE_write_HAL(uint8_t c);
 void keyboardBLE_longpress_HAL(uint8_t c);
 void keyboardBLE_home_HAL();

--- a/Platformio/hardware/windows_linux/mqtt_hal_windows_linux.cpp
+++ b/Platformio/hardware/windows_linux/mqtt_hal_windows_linux.cpp
@@ -211,7 +211,7 @@ bool publishMQTTMessage_HAL(const char *topic, const char *payload) {
   return true;
 }
 
-void wifiStop_HAL() {
+void wifi_shutdown_HAL() {
   /* disconnect */
   if (sockfd != -1) {
     mqtt_disconnect(&mqttClient);

--- a/Platformio/hardware/windows_linux/mqtt_hal_windows_linux.h
+++ b/Platformio/hardware/windows_linux/mqtt_hal_windows_linux.h
@@ -6,7 +6,7 @@ void init_mqtt_HAL(void);
 bool getIsWifiConnected_HAL();
 void mqtt_loop_HAL();
 bool publishMQTTMessage_HAL(const char *topic, const char *payload);
-void wifiStop_HAL();
+void wifi_shutdown_HAL();
 
 typedef void (*tAnnounceWiFiconnected_cb)(bool connected);
 void set_announceWiFiconnected_cb_HAL(tAnnounceWiFiconnected_cb pAnnounceWiFiconnected_cb);

--- a/Platformio/src/applicationInternal/hardware/hardwarePresenter.cpp
+++ b/Platformio/src/applicationInternal/hardware/hardwarePresenter.cpp
@@ -204,8 +204,8 @@ bool keyboardBLE_isAdvertising() {
 bool keyboardBLE_isConnected() {
   return keyboardBLE_isConnected_HAL();
 }
-void keyboardBLE_end() {
-  keyboardBLE_end_HAL();
+void keyboard_ble_shutdown() {
+  keyboard_ble_shutdown_HAL();
 }
 void keyboardBLE_write(uint8_t c) {
   keyboardBLE_write_HAL(c);
@@ -260,8 +260,8 @@ void mqtt_loop() {
 bool publishMQTTMessage(const char *topic, const char *payload) {
   return publishMQTTMessage_HAL(topic, payload);
 }
-void wifiStop() {
-  wifiStop_HAL();
+void wifi_shutdown() {
+  wifi_shutdown_HAL();
 }
 #endif
 

--- a/Platformio/src/applicationInternal/hardware/hardwarePresenter.h
+++ b/Platformio/src/applicationInternal/hardware/hardwarePresenter.h
@@ -4,6 +4,7 @@
 #include <string>
 #include "applicationInternal/hardware/arduinoLayer.h"
 
+
 // --- hardware general -------------------------------------------------------
 void init_hardware_general(void);
 
@@ -115,7 +116,7 @@ void keyboardBLE_deleteBonds();
 bool keyboardBLE_forceConnectionToAddress(std::string peerAddress);
 bool keyboardBLE_isAdvertising();
 bool keyboardBLE_isConnected();
-void keyboardBLE_end();
+void keyboard_ble_shutdown();
 void keyboardBLE_write(uint8_t c);
 void keyboardBLE_longpress(uint8_t c);
 void keyboardBLE_home();
@@ -139,7 +140,7 @@ void init_mqtt(void);
 bool getIsWifiConnected();
 void mqtt_loop();
 bool publishMQTTMessage(const char *topic, const char *payload);
-void wifiStop();
+void wifi_shutdown();
 #endif
 
 // --- memory usage -----------------------------------------------------------


### PR DESCRIPTION
While adding hub support to the OMOTE, I couldn't resist refactoring some inconsistent naming.