### PR TITLE
Update usage of sprintf to use snprintf.

### DIFF
--- a/Platformio/hardware/ESP32/lib/ESP32-BLE-Keyboard/BleKeyboard.cpp
+++ b/Platformio/hardware/ESP32/lib/ESP32-BLE-Keyboard/BleKeyboard.cpp
@@ -542,7 +542,7 @@ void BleKeyboard::onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) {
     #if !defined(NIMBLE_ARDUINO_2_x)
     NimBLEConnInfo connInfo = pServer->getPeerInfo(0);
     #endif
-    sprintf(buffer, "BleKeyboard: onConnect: client %s%s, id %s%s, handle %u, isBonded %d",
+    snprintf(buffer, sizeof(buffer), "BleKeyboard: onConnect: client %s%s, id %s%s, handle %u, isBonded %d",
       NimBLEAddress(connInfo.getAddress()).toString().c_str(),
       this->getAddressTypeStr(connInfo.getAddress()).c_str(),
       NimBLEAddress(connInfo.getIdAddress()).toString().c_str(),
@@ -550,7 +550,7 @@ void BleKeyboard::onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) {
       connInfo.getConnHandle(),
       connInfo.isBonded());
   } else {
-    sprintf(buffer, "BleKeyboard: onConnect: more than one device connected. How can it be???");
+    snprintf(buffer, sizeof(buffer), "BleKeyboard: onConnect: more than one device connected. How can it be???");
   }
 	ESP_LOGI(LOG_TAG, "%s", buffer);
   if (thisBLEKeyboardMessage_cb != NULL) {
@@ -570,7 +570,7 @@ void BleKeyboard::onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, std
     #if !defined(NIMBLE_ARDUINO_2_x)
     NimBLEConnInfo connInfo = pServer->getPeerInfo(0);
     #endif
-    sprintf(buffer, "BleKeyboard: onConnect with name: client %s%s, id %s%s, handle %u, isBonded %d, name %s",
+    snprintf(buffer, sizeof(buffer), "BleKeyboard: onConnect with name: client %s%s, id %s%s, handle %u, isBonded %d, name %s",
       NimBLEAddress(connInfo.getAddress()).toString().c_str(),
       this->getAddressTypeStr(connInfo.getAddress()).c_str(),
       NimBLEAddress(connInfo.getIdAddress()).toString().c_str(),
@@ -579,7 +579,7 @@ void BleKeyboard::onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, std
       connInfo.isBonded(),
       name.c_str());
   } else {
-    sprintf(buffer, "BleKeyboard: onConnect with name: more than one device connected. How can it be???");
+    snprintf(buffer, sizeof(buffer), "BleKeyboard: onConnect with name: more than one device connected. How can it be???");
   }
 	ESP_LOGI(LOG_TAG, "%s", buffer);
   if (thisBLEKeyboardMessage_cb != NULL) {
@@ -599,12 +599,12 @@ void BleKeyboard::onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, 
   std::string message = "";
   char buffer[200];
   if (pServer->getConnectedCount() == 0) {
-  	sprintf(buffer, "BleKeyboard: onDisconnect: no clients connected");
+  	snprintf(buffer, sizeof(buffer), "BleKeyboard: onDisconnect: no clients connected");
   } else if (pServer->getConnectedCount() == 1) {
     #if !defined(NIMBLE_ARDUINO_2_x)
     NimBLEConnInfo connInfo = pServer->getPeerInfo(0);
     #endif
-    sprintf(buffer, "BleKeyboard: onDisconnect: there is still a client connected %s%s, id %s%s, handle %u, isBonded %d. How can it be???",
+    snprintf(buffer, sizeof(buffer), "BleKeyboard: onDisconnect: there is still a client connected %s%s, id %s%s, handle %u, isBonded %d. How can it be???",
       NimBLEAddress(connInfo.getAddress()).toString().c_str(),
       this->getAddressTypeStr(connInfo.getAddress()).c_str(),
       NimBLEAddress(connInfo.getIdAddress()).toString().c_str(),
@@ -612,7 +612,7 @@ void BleKeyboard::onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, 
       connInfo.getConnHandle(),
       connInfo.isBonded());
   } else {
-  	sprintf(buffer, "BleKeyboard: onDisconnect: there are still %d devices connected. How can it be???", pServer->getConnectedCount());
+  	snprintf(buffer, sizeof(buffer), "BleKeyboard: onDisconnect: there are still %d devices connected. How can it be???", pServer->getConnectedCount());
   }
   ESP_LOGI(LOG_TAG, "%s", buffer);
   if (thisBLEKeyboardMessage_cb != NULL) {
@@ -626,7 +626,7 @@ void BleKeyboard::onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, 
 void BleKeyboard::onIdentity(NimBLEConnInfo& connInfo) {
   std::string message = "";
   char buffer[200];
-  sprintf(buffer, "BleKeyboard: onIdentity: client %s%s, id %s%s, handle %u, isBonded %d",
+  snprintf(buffer, sizeof(buffer), "BleKeyboard: onIdentity: client %s%s, id %s%s, handle %u, isBonded %d",
     NimBLEAddress(connInfo.getAddress()).toString().c_str(),
     this->getAddressTypeStr(connInfo.getAddress()).c_str(),
     NimBLEAddress(connInfo.getIdAddress()).toString().c_str(),
@@ -765,7 +765,7 @@ void BleKeyboard::startAdvertisingDirected(std::string peerAddress, bool isRando
 
   std::string message = "";
   char buffer[100];
-  sprintf(buffer, "Direct advertising started to address %s%s",
+  snprintf(buffer, sizeof(buffer), "Direct advertising started to address %s%s",
     directedAddress.toString().c_str(),
     this->getAddressTypeStr(directedAddress).c_str());
   ESP_LOGI(LOG_TAG, "%s", buffer);
@@ -785,7 +785,7 @@ void BleKeyboard::printConnectedClients() {
   std::string message = "";
   char buffer[50];
 
-  sprintf(buffer, "Connected count: %d", NimBLEDevice::getServer()->getConnectedCount());
+  snprintf(buffer, sizeof(buffer), "Connected count: %d", NimBLEDevice::getServer()->getConnectedCount());
   message = buffer;
   ESP_LOGI(LOG_TAG, "%s", buffer);
 
@@ -796,7 +796,7 @@ void BleKeyboard::printConnectedClients() {
     #else
     NimBLEConnInfo connInfo = NimBLEDevice::getServer()->getPeerInfoByHandle(*it);
     #endif
-    sprintf(buffer, "\n client %d: %s", *it, NimBLEAddress(connInfo.getAddress()).toString().c_str());
+    snprintf(buffer, sizeof(buffer), "\n client %d: %s", *it, NimBLEAddress(connInfo.getAddress()).toString().c_str());
     message = message + buffer;
     ESP_LOGI(LOG_TAG, "%s", buffer);
   }
@@ -820,12 +820,12 @@ void BleKeyboard::printBonds() {
 
   // https://github.com/h2zero/NimBLE-Arduino/issues/579
 
-  sprintf(buffer, "NumBonds: %d", NimBLEDevice::getNumBonds());
+  snprintf(buffer, sizeof(buffer), "NumBonds: %d", NimBLEDevice::getNumBonds());
   message = buffer;
   ESP_LOGI(LOG_TAG, "%s", buffer);
 
   for (int i=0; i<NimBLEDevice::getNumBonds(); i++) {
-    sprintf(buffer, "\n bond %d: %s", i, NimBLEDevice::getBondedAddress(i).toString().c_str());
+    snprintf(buffer, sizeof(buffer), "\n bond %d: %s", i, NimBLEDevice::getBondedAddress(i).toString().c_str());
     message = message + buffer;
     ESP_LOGI(LOG_TAG, "%s", buffer);
   }

--- a/Platformio/src/applicationInternal/gui/guiMemoryOptimizer.cpp
+++ b/Platformio/src/applicationInternal/gui/guiMemoryOptimizer.cpp
@@ -248,7 +248,7 @@ void setGUIlistIndicesToBeShown_afterSlide(t_gui_state *gui_state) {
     // swipe to previous item in list
     omote_log_d("  Will swipe to previous item in list\r\n");
     oldListIndex = gui_state->gui_on_tab[1].gui_list_index_previous;
-    if ((oldListIndex == 1)) {
+    if (oldListIndex == 1) {
       // next state is the "first state"
       gui_state->gui_on_tab[0] = {NULL, "", 0};
       gui_state->gui_on_tab[1] = {NULL, "", 1};

--- a/Platformio/src/applicationInternal/gui/guiStatusUpdate.cpp
+++ b/Platformio/src/applicationInternal/gui/guiStatusUpdate.cpp
@@ -12,7 +12,7 @@ void updateBatteryStatusOnGUI() {
   get_battery_status(&battery_voltage, &battery_percentage, &battery_ischarging);
 
   char buffer1[20];
-  sprintf(buffer1, "Voltage: %.2f V", (float)battery_voltage / 1000);
+  snprintf(buffer1, sizeof(buffer1), "Voltage: %.2f V", (float)battery_voltage / 1000);
 
   // GUI settings
   if (objBattSettingsVoltage    != NULL) {lv_label_set_text_fmt(objBattSettingsVoltage, "%s", buffer1);}
@@ -22,9 +22,9 @@ void updateBatteryStatusOnGUI() {
   // GUI status bar at the top
   char buffer2[12];
   // Voltage and percentage
-  // sprintf(buffer2, "%.1fV, %d%%", (float)getBatteryVoltage() / 1000, battery_percentage);
+  // snprintf(buffer2, sizeof(buffer2), "%.1fV, %d%%", (float)getBatteryVoltage() / 1000, battery_percentage);
   // only percentage
-  sprintf(buffer2, "%d%%", battery_percentage);
+  snprintf(buffer2, sizeof(buffer2), "%d%%", battery_percentage);
   for (int i=0; i<strlen(buffer2); i++) {
     if (buffer2[i] == '.') {
       buffer2[i] = ',';

--- a/Platformio/src/applicationInternal/memoryUsage.cpp
+++ b/Platformio/src/applicationInternal/memoryUsage.cpp
@@ -98,15 +98,15 @@ void doLogMemoryUsage() {
     #if LV_MEM_CUSTOM != 0
       #ifdef SHOW_USED_MEMORY_INSTEAD_OF_FREE_IN_GUI
 
-      sprintf(buffer, ESP32HeapWarnBegin.append("%lu/%lu (%.0f%%)").append(ESP32HeapWarnEnd).c_str()                                                                                           , systemHeapSize-freeSystemHeap, systemHeapSize, float(systemHeapSize-freeSystemHeap) / systemHeapSize * 100);
+      snprintf(buffer, sizeof(buffer), ESP32HeapWarnBegin.append("%lu/%lu (%.0f%%)").append(ESP32HeapWarnEnd).c_str()                                                                                           , systemHeapSize-freeSystemHeap, systemHeapSize, float(systemHeapSize-freeSystemHeap) / systemHeapSize * 100);
       #else
-      sprintf(buffer, ESP32HeapWarnBegin.append("%lu/%lu (%.0f%%)").append(ESP32HeapWarnEnd).c_str()                                                                                           , freeSystemHeap,                systemHeapSize, float(freeSystemHeap)                / systemHeapSize * 100);
+      snprintf(buffer, sizeof(buffer), ESP32HeapWarnBegin.append("%lu/%lu (%.0f%%)").append(ESP32HeapWarnEnd).c_str()                                                                                           , freeSystemHeap,                systemHeapSize, float(freeSystemHeap)                / systemHeapSize * 100);
       #endif
     #else
       #ifdef SHOW_USED_MEMORY_INSTEAD_OF_FREE_IN_GUI
-      sprintf(buffer, ESP32HeapWarnBegin.append("%lu/%lu (%.0f%%)").append(ESP32HeapWarnEnd).append(" / ").append(LVGLMemorWarnBegin).append("%lu/%lu (%d%%)").append(LVGLMemorWarnEnd).c_str(), systemHeapSize-freeSystemHeap, systemHeapSize, float(systemHeapSize-freeSystemHeap) / systemHeapSize * 100, mon.total_size - mon.free_size, mon.total_size, mon.used_pct);
+      snprintf(buffer, sizeof(buffer), ESP32HeapWarnBegin.append("%lu/%lu (%.0f%%)").append(ESP32HeapWarnEnd).append(" / ").append(LVGLMemorWarnBegin).append("%lu/%lu (%d%%)").append(LVGLMemorWarnEnd).c_str(), systemHeapSize-freeSystemHeap, systemHeapSize, float(systemHeapSize-freeSystemHeap) / systemHeapSize * 100, mon.total_size - mon.free_size, mon.total_size, mon.used_pct);
       #else
-      sprintf(buffer, ESP32HeapWarnBegin.append("%lu/%lu (%.0f%%)").append(ESP32HeapWarnEnd).append(" / ").append(LVGLMemorWarnBegin).append("%lu/%lu (%d%%)").append(LVGLMemorWarnEnd).c_str(), freeSystemHeap,                systemHeapSize, float(freeSystemHeap)                / systemHeapSize * 100, mon.free_size,                  mon.total_size, 100-mon.used_pct);
+      snprintf(buffer, sizeof(buffer), ESP32HeapWarnBegin.append("%lu/%lu (%.0f%%)").append(ESP32HeapWarnEnd).append(" / ").append(LVGLMemorWarnBegin).append("%lu/%lu (%d%%)").append(LVGLMemorWarnEnd).c_str(), freeSystemHeap,                systemHeapSize, float(freeSystemHeap)                / systemHeapSize * 100, mon.free_size,                  mon.total_size, 100-mon.used_pct);
       #endif
     #endif
 

--- a/Platformio/src/devices/misc/device_smarthome/gui_smarthome.cpp
+++ b/Platformio/src/devices/misc/device_smarthome/gui_smarthome.cpp
@@ -45,7 +45,7 @@ static void smartHomeToggle_event_cb(lv_event_t* e){
 static void smartHomeSlider_event_cb(lv_event_t* e){
   lv_obj_t* slider = lv_event_get_target(e);
   char payload[8];
-  sprintf(payload, "%.2f", float(lv_slider_get_value(slider)));
+  snprintf(payload, sizeof(payload), "%.2f", float(lv_slider_get_value(slider)));
   std::string payload_str(payload);
   // Publish an MQTT message based on the event user data
   #if (ENABLE_WIFI_AND_MQTT == 1)

--- a/Platformio/src/devices_pool/misc/device_airconditioner/device_airconditioner.cpp
+++ b/Platformio/src/devices_pool/misc/device_airconditioner/device_airconditioner.cpp
@@ -276,7 +276,7 @@ void AirConditionerPAC_N81::sendIRcommand() {
   unsigned long msg_on_hex = dl_assemble_msg(&airconditioner_state);
   //omote_log_d("AC hex command: 0x%lx\r\n", msg_on_hex);
   char buffer[12];
-  sprintf(buffer, "0x%lx", msg_on_hex);
+  snprintf(buffer, sizeof(buffer), "0x%lx", msg_on_hex);
   //omote_log_d("buffer: %s\r\n", buffer);
   executeCommand(AIRCONDITIONER_COMMAND, std::string(buffer));
 


### PR DESCRIPTION
When building using `default_envs = macOS` in the platformio.ini file there are a number of build warnings like this:
**'sprintf' is deprecated: This function is provided for compatibility reasons only. Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]**

As discussed on the discord I've updated these using the `snprintf([variableName], sizeof([variableName]), ..)` pattern.
