### PR TITLE
Adding Support For IR Protocol Customization

### DIFF
--- a/Platformio/hardware/ESP32/infrared_sender_hal_esp32.cpp
+++ b/Platformio/hardware/ESP32/infrared_sender_hal_esp32.cpp
@@ -21,16 +21,80 @@ void init_infraredSender_HAL(void) {
   IrSender.begin();
 }
 
-// IR protocols
+/// @brief Supported IR Protocols.
 enum IRprotocols {
+  /// @brief Standard Global Cache IR protocol. 
   IR_PROTOCOL_GC = 0,
+  /// @brief Standard NEC IR protocol. 
   IR_PROTOCOL_NEC = 1,
+  /// @brief Standard Samsung IR protocol.
   IR_PROTOCOL_SAMSUNG = 2,
+  /// @brief Sony IR protocol operating with 15 bits not the default 20 bits.
   IR_PROTOCOL_SONY = 3,
+  /// @brief Standard RC5 IR protocol.
   IR_PROTOCOL_RC5 = 4,
+  /// @brief Denon IR protocol operating with 48 bits not the default 48 bits.
   IR_PROTOCOL_DENON = 5,
-  IR_PROTOCOL_SAMSUNG36 = 6
+  /// @brief Standard SAMSUNG 36 bit IR protocol.
+  IR_PROTOCOL_SAMSUNG36 = 6,
 };
+
+/// @brief Gets the default IR repeat number.
+/// @param protocol Which protocol to get the default for.
+/// @return The default to use for the repeat. This is the default for the 
+///         relevant IrSender.send api.
+uint16_t getProtocolDefaultRepeat(int protocol) {
+  switch (protocol) {
+    case IR_PROTOCOL_SONY: {
+      // Sony protocol by default needs 2 repeats.
+      return 2;
+    }
+    default: {
+      return 0;
+    }
+  }
+}
+
+/// @brief Gets the defualt IR bits to send.
+/// @param protocol Which protocol to get the default for.
+/// @return The default to use for the repeat. This is mostly default for the 
+///         relevant IrSender.send api.
+uint16_t getProtocolDefaultBits(int protocol) {
+  switch (protocol) {
+    case IR_PROTOCOL_NEC: {
+      return 32;
+    }
+
+    case IR_PROTOCOL_SAMSUNG: {
+      return 32;
+    }
+
+    case IR_PROTOCOL_SONY: {
+      // This is actually not the default but it's the default that was 
+      // selected for the enum value. The API default is 20.
+      return 15;
+    }
+
+    case IR_PROTOCOL_RC5: {
+      return 13;
+    }
+
+    case IR_PROTOCOL_DENON: {
+      // This is actually not the default but it's the default that was 
+      // selected for the enum value. The API default is 15.
+      return 48;
+    }
+
+    case IR_PROTOCOL_SAMSUNG36: {
+      return 38;
+    }
+
+    default: {
+      return 0;
+    }
+  }
+}
+
 void sendIRcode_HAL(int protocol, std::list<std::string> commandPayloads, std::string additionalPayload) {
 
   // first determine if data was provided by commandPayload or by additionalPayload. Only one of these will be used.
@@ -38,15 +102,57 @@ void sendIRcode_HAL(int protocol, std::list<std::string> commandPayloads, std::s
   std::string dataStr;
   uint64_t data;
   if (commandPayloads.empty() && (additionalPayload == "")) {
-    Serial.printf("execute: cannot send IR command, because both data and payload are empty\r\n");
+    Serial.printf("sendIRcode_HAL: cannot send IR command, because both data and payload are empty.\r\n");
     return;
   } else {
     if (additionalPayload != "") {
+      Serial.printf("sendIRcode_HAL: Setting data stream to additional payload.\r\n");
       dataStr = additionalPayload;
     } else {
       auto current = commandPayloads.begin();
       dataStr = *current;
     }
+  }
+  
+  uint16_t repeat = getProtocolDefaultRepeat(protocol);
+  uint16_t nbits = getProtocolDefaultBits(protocol);
+
+  if (protocol != IR_PROTOCOL_GC)
+  {
+    std::string::difference_type elementCount = std::count(dataStr.begin(), dataStr.end(), ':');
+    elementCount++;
+    std::string valueAsStr;
+
+    if (elementCount == 3)
+    {
+        std::stringstream dataStrAsStream(dataStr);
+  
+        std::getline(dataStrAsStream, valueAsStr, ':');
+        data = std::stoull(valueAsStr, nullptr, 0);
+
+        std::getline(dataStrAsStream, valueAsStr, ':');
+        repeat = std::stoull(valueAsStr, nullptr, 0);
+
+        std::getline(dataStrAsStream, valueAsStr, ':');
+        nbits = std::stoull(valueAsStr, nullptr, 0);
+    }
+    else if (elementCount == 2)
+    {
+        std::stringstream dataStrAsStream(dataStr);
+        
+        std::string valueAsStr;
+        uint64_t valueAsUint64;
+
+        std::getline(dataStrAsStream, valueAsStr, ':');
+        data = std::stoull(valueAsStr, nullptr, 0);
+
+        std::getline(dataStrAsStream, valueAsStr, ':');
+        repeat = std::stoull(valueAsStr, nullptr, 0);
+      }
+      else
+      {
+        data = std::stoull(dataStr, &sz, 0);
+      }
   }
 
   switch (protocol) {
@@ -67,52 +173,58 @@ void sendIRcode_HAL(int protocol, std::list<std::string> commandPayloads, std::s
         buf[pos] = data;
         pos += 1;
       }
-      Serial.printf("execute: will send IR GC, array size %d\r\n", size);
+      Serial.printf("sendIRcode_HAL: will send IR GC, array size '%d'.\r\n", size);
       IrSender.sendGC(buf, size);
       delete [] buf;
       break;
     }
 
     case IR_PROTOCOL_NEC: {
-      data = std::stoull(dataStr, &sz, 0);
-      Serial.printf("execute: will send IR NEC, data %s (%" PRIu64 ")\r\n", dataStr.c_str(), data);
-      IrSender.sendNEC(data);
+      Serial.printf("sendIRcode_HAL: will send IR NEC, command: '%s', data: (%" PRIu64 "), bits: (%" PRIu64 "), repeat: (%" PRIu64 ").\r\n", 
+        dataStr.c_str(), data, nbits, repeat);
+      IrSender.sendNEC(data, nbits, repeat);
       break;
     }
 
     case IR_PROTOCOL_SAMSUNG: {
-      data = std::stoull(dataStr, &sz, 0);
-      Serial.printf("execute: will send IR SAMSUNG, data %s (%" PRIu64 ")\r\n", dataStr.c_str(), data);
-      IrSender.sendSAMSUNG(data);
+      Serial.printf("sendIRcode_HAL: will send IR SAMSUNG, command: '%s', data: (%" PRIu64 "), bits: (%" PRIu64 "), repeat: (%" PRIu64 ").\r\n", 
+        dataStr.c_str(), data, nbits, repeat);
+      IrSender.sendSAMSUNG(data, nbits, repeat);
       break;
     }
 
     case IR_PROTOCOL_SONY: {
-      data = std::stoull(dataStr, &sz, 0);
-      Serial.printf("execute: will send IR SONY 15 bit, data %s (%" PRIu64 ")\r\n", dataStr.c_str(), data);
-      IrSender.sendSony(data, 15);
+      Serial.printf("sendIRcode_HAL: will send IR SONY, command: '%s', data: (%" PRIu64 "), bits: (%" PRIu64 "), repeat: (%" PRIu64 ").\r\n", 
+        dataStr.c_str(), data, nbits, repeat);
+      IrSender.sendSony(data,  nbits, repeat);
       break;
     }
 
     case IR_PROTOCOL_RC5: {
-      data = std::stoull(dataStr, &sz, 0);
-      Serial.printf("execute: will send IR RC5, data %s (%" PRIu64 ")\r\n", dataStr.c_str(), data);
-      IrSender.sendRC5(IrSender.encodeRC5X(0x00, data));
+      Serial.printf("sendIRcode_HAL: will send IR RC5, command: '%s', data: (%" PRIu64 "), bits: (%" PRIu64 "), repeat: (%" PRIu64 ").\r\n", 
+        dataStr.c_str(), data, nbits, repeat);
+      IrSender.sendRC5(IrSender.encodeRC5X(0x00, data),  nbits, repeat);
       break;
     }
 
     case IR_PROTOCOL_DENON: {
-      data = std::stoull(dataStr, &sz, 0);
-      Serial.printf("execute: will send IR DENON 48 bit, data %s (%" PRIu64 ")\r\n", dataStr.c_str(), data);
-      IrSender.sendDenon(data, 48);
+      Serial.printf("sendIRcode_HAL: will send IR DENON, command: '%s', data: (%" PRIu64 "), bits: (%" PRIu64 "), repeat: (%" PRIu64 ").\r\n", 
+        dataStr.c_str(), data, nbits, repeat);
+      IrSender.sendDenon(data, nbits, repeat);
       break;
     }
 
     case IR_PROTOCOL_SAMSUNG36: {
       data = std::stoull(dataStr, &sz, 0);
-      Serial.printf("execute: will send IR SAMSUNG36, data %s (%" PRIu64 ")\r\n", dataStr.c_str(), data);
-      IrSender.sendSamsung36(data);
+      Serial.printf("sendIRcode_HAL: will send IR SAMSUNG36, command: '%s', data: (%" PRIu64 "), bits: (%" PRIu64 "), repeat: (%" PRIu64 ").\r\n", 
+        dataStr.c_str(), data, nbits, repeat);
+      IrSender.sendSamsung36(data, nbits, repeat);
       break;
+    }
+
+    default: {
+      Serial.printf("sendIRcode_HAL: Unknwon protocol '%i'.\r\n", protocol);
+      return;
     }
   }
 }


### PR DESCRIPTION
Adds the ability to specify the bit and repeat count for a protocol using a pattern like this:
makeCommandData(IR, {std::to_string(IR_PROTOCOL_NEC), "0xA7E16480:1:32"})

The format is [data]:[repeat]:[bits] or [data]:[repeat].